### PR TITLE
Typo in the notebook on the Runge–Kutta method

### DIFF
--- a/notebooks/c_mathematics/numerical_methods/5_Runge_Kutta_method.ipynb
+++ b/notebooks/c_mathematics/numerical_methods/5_Runge_Kutta_method.ipynb
@@ -716,7 +716,7 @@
     "\n",
     "At first we need to change the first equation to involve $H$:\n",
     "\n",
-    "$$\\frac{d^2\\tau}{dx^2}=\\frac{d}{dx}\\left(\\frac{dx}{d\\tau}\\right), \\quad \\frac{d\\tau}{dx}=-H.$$\n",
+    "$$\\frac{d^2\\tau}{dx^2}=\\frac{d}{dx}\\left(\\frac{d\\tau}{dx}\\right), \\quad \\frac{d\\tau}{dx}=-H.$$\n",
     "\n",
     "Therefore,\n",
     "\n",


### PR DESCRIPTION
This commit fixes a potentially confusing typo in one of the equations in the "Runge–Kutta method" notebook.